### PR TITLE
🐛 fixed readItems sort query param types

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 # General
 
 PORT=8055
+# For Windows users, replace 'localhost' by '127.0.0.1'
 PUBLIC_URL="http://localhost:8055"
 
 # Admin

--- a/src/items/readItems.test.ts
+++ b/src/items/readItems.test.ts
@@ -59,6 +59,66 @@ describe('readItems', () => {
     expect(items.map((item) => item.last_name)).toMatchObject(['Doe', 'Doe']);
   });
 
+  test('should read items with sorting asc', async () => {
+    await createItems(adminClient, 'directus_users', [
+      {
+        first_name: 'John',
+        last_name: 'Doe',
+      },
+      {
+        first_name: 'Jane',
+        last_name: 'Doe',
+      },
+    ]);
+    const [items] = await readItems(adminClient, 'directus_users', {
+      filter: {
+        last_name: {
+          _eq: 'Doe',
+        },
+      },
+      sort: {
+        first_name: true,
+      },
+    });
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.first_name)).toContain('Jane');
+    expect(items.map((item) => item.first_name)).toContain('John');
+    expect(items.map((item) => item.first_name)).toMatchObject([
+      'Jane',
+      'John',
+    ]);
+  });
+
+  test('should read items with sorting desc', async () => {
+    await createItems(adminClient, 'directus_users', [
+      {
+        first_name: 'Jane',
+        last_name: 'Doe',
+      },
+      {
+        first_name: 'John',
+        last_name: 'Doe',
+      },
+    ]);
+    const [items] = await readItems(adminClient, 'directus_users', {
+      filter: {
+        last_name: {
+          _eq: 'Doe',
+        },
+      },
+      sort: {
+        '-first_name': true,
+      },
+    });
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.first_name)).toContain('Jane');
+    expect(items.map((item) => item.first_name)).toContain('John');
+    expect(items.map((item) => item.first_name)).toMatchObject([
+      'John',
+      'Jane',
+    ]);
+  });
+
   test('should return only first name', async () => {
     const { id } = await createItem(adminClient, 'directus_users', {
       first_name: 'Jane',

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -40,9 +40,18 @@ export type ItemQuery<TItem extends Item<ItemData>> = DataQuery<TItem> & {
 };
 
 /**
+ * Handle item keys that start with a hyphen (for desc sorting).
+ */
+export type HyphenPrefixProperties<T> = {
+  [K in keyof T as `-${string & K}`]: T[K];
+};
+
+export type MaybeHyphenPrefixed<T> = T & HyphenPrefixProperties<T>;
+
+/**
  * Value type of the sort query.
  */
-export type SortQuery<TItem extends Item<ItemData>> = {
+export type SortQuery<TItem extends MaybeHyphenPrefixed<Item<ItemData>>> = {
   [TKey in keyof Omit<TItem, '__item__' | '__relation__'>]?: Maybe<
     TItem[TKey] extends Relation<Item<ItemData>>[]
       ? true | FieldsQuery<TItem[TKey][number]>
@@ -56,7 +65,7 @@ export type SortQuery<TItem extends Item<ItemData>> = {
  * Value type of the items query.
  */
 export type ItemsQuery<TItem extends Item<ItemData>> = ItemQuery<TItem> & {
-  sort?: Maybe<SortQuery<TItem>>;
+  sort?: Maybe<SortQuery<MaybeHyphenPrefixed<TItem>>>;
   limit?: Maybe<number>;
   offset?: Maybe<number>;
   page?: Maybe<number>;


### PR DESCRIPTION
## Context

The `readItems(/* ... */)` method's sorting functionality was working nicely. However, the `SortQuery</* ... */>` associated with it was not handling the possibility to sort in a descending direction (with the hyphen prefix, see [Directus official documentation](https://docs.directus.io/reference/query.html#sort)).

## Review Guide

Two new types have been introduced in [query.ts](src/types/query.ts):
- `HyphenPrefixProperties<T>` creates a copy of object keys prefixed with a hyphen.
- `MaybeHyphenPrefixed<T>` extends an object with its properties prefixed with a hyphen.

No changes have been made in [readItems.ts](src/items/readItems.ts) as only the types were causing the issue.

## Tests

Tests have been added in `readItems.test.ts` to cover code changes (asserting sorting in ascending and descending directions).

## Checklist

- [x] I have self-reviewed my work.
- [x] I have managed to write tests that cover my changes.

## What's next

- Improve documentation to explicitly explain the different use cases.
