### PR TITLE
✨ updated types to support wildcards and nested wildcards queries

### DIFF
--- a/src/items/readItem.ts
+++ b/src/items/readItem.ts
@@ -25,6 +25,7 @@ import {
  *
  * @returns The item.
  */
+// @ts-expect-error: Type instantiation is excessively deep and possibly infinite
 export async function readItem<
   TCollections extends Collections,
   TCollection extends GetCollection<TCollections>,

--- a/src/items/readItems.ts
+++ b/src/items/readItems.ts
@@ -73,6 +73,7 @@ export async function readItems<
 > {
   // If arg3 is an array, read each by key
   if (Array.isArray(arg3)) {
+    // @ts-expect-error: Type instantiation is excessively deep and possibly infinite
     return Promise.all(
       arg3.map((key) =>
         readItem<TCollections, TCollection, TItem, TQuery>(

--- a/src/items/updateItem.ts
+++ b/src/items/updateItem.ts
@@ -22,6 +22,7 @@ import { fetchDirectus, getBasePath, getDataQueryParams } from '../utils';
  *
  * @returns The item.
  */
+// @ts-expect-error: Type instantiation is excessively deep and possibly infinite
 export async function updateItem<
   TCollections extends Collections,
   TCollection extends GetCollection<TCollections>,

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -6,13 +6,29 @@ import type { Maybe } from './utils';
  * Value type of the fields query.
  */
 export type FieldsQuery<TItem extends Item<ItemData>> = {
-  [TKey in keyof Omit<TItem, '__item__' | '__relation__'>]?: Maybe<
+  [TKey in keyof Omit<
+    WithWildcardItem<TItem>,
+    '__item__' | '__relation__'
+  >]?: Maybe<
     TItem[TKey] extends Relation<Item<ItemData>>[]
       ? true | '*' | FieldsQuery<TItem[TKey][number]>
       : TItem[TKey] extends Relation<Item<ItemData>> | null
       ? true | '*' | FieldsQuery<NonNullable<TItem[TKey]>>
+      : TKey extends '*'
+      ? true | RecursiveWilthCard<TItem[TKey]>
       : true
   >;
+};
+
+/**
+ * Accepts wildcard as query key of item.
+ */
+export type WithWildcardItem<TItemData extends ItemData> = TItemData & {
+  '*': true;
+};
+
+export type RecursiveWilthCard<T> = {
+  '*': true | RecursiveWilthCard<T>;
 };
 
 /**

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -8,66 +8,84 @@ import type {
   Relation,
 } from './item';
 import type { DataQuery, ItemsQuery } from './query';
+import type { Primitive } from './utils';
 
 /**
- * Returns the top level fileds of an item.
+ * Returns the top level fields of an item.
  */
 export type TopLevelFields<TItem> = {
   [TKey in keyof Omit<TItem, '__item__' | '__relation__'>]: true;
 };
 
 /**
+ * Returns the top level fields of an item.
+ */
+export type RecursiveTopLevelFields<TItem, Recursive extends '*' | true> = {
+  [TKey in keyof Omit<
+    TItem,
+    '__item__' | '__relation__'
+  >]: TItem[TKey] extends Primitive ? true : Recursive;
+};
+
+/**
  * Filters the item data by the fields query.
  */
-export type FilterItemByFields<TItem, TFields> =
-  // If fields are undefined, filter by top level fields
+export type FilterItemByFields<TItem, TFields> = '*' extends keyof TFields
+  ? FilterItemByFields<
+      TItem,
+      RecursiveTopLevelFields<
+        TItem,
+        '*' extends keyof TFields['*'] ? '*' : true
+      >
+    >
+  : // If fields are undefined, filter by top level fields
   undefined extends TFields
-    ? FilterItemByFields<TItem, TopLevelFields<TItem>>
-    : // Otherwise filter each key of fields individually
-      {
-        [TKey1 in keyof TFields]: TKey1 extends keyof TItem
-          ? // If value of field is an object, filter nested fields
-            TFields[TKey1] extends Record<string, any>
-            ? TItem[TKey1] extends Relation<Item<ItemData>>[]
-              ? FilterItemByFields<TItem[TKey1][number], TFields[TKey1]>[]
-              : TItem[TKey1] extends Relation<Item<ItemData>>
-              ? FilterItemByFields<TItem[TKey1], TFields[TKey1]>
-              : FilterItemByFields<
-                  NonNullable<TItem[TKey1]>,
-                  TFields[TKey1]
-                > | null
-            : // If value of field is a wildcard, filter by top level fields
-            TFields[TKey1] extends '*'
-            ? TItem[TKey1] extends Relation<Item<ItemData>>[]
-              ? FilterItemByFields<
-                  TItem[TKey1][number],
-                  TopLevelFields<TItem[TKey1][number]>
-                >[]
-              : TItem[TKey1] extends Relation<Item<ItemData>>
-              ? FilterItemByFields<TItem[TKey1], TopLevelFields<TItem[TKey1]>>
-              : FilterItemByFields<
-                  NonNullable<TItem[TKey1]>,
-                  TopLevelFields<NonNullable<TItem[TKey1]>>
-                > | null
-            : // If value of field is "true", return value of item
-            TFields[TKey1] extends true
-            ? // If value of item is an array of relation, return array of item keys
-              TItem[TKey1] extends Relation<Item<ItemData>>[]
-              ? ItemKey[]
-              : // If value of item is a relation, return item key
-              TItem[TKey1] extends Relation<Item<ItemData>>
-              ? ItemKey
-              : // If value of item is a relation, return item key
-              TItem[TKey1] extends Relation<Item<ItemData>> | null
-              ? ItemKey | null
-              : // If value of item is JSON, return it without __json__
-              TItem[TKey1] extends Json<JsonData>
-              ? Omit<TItem[TKey1], '__json__'>
-              : // Otherwise return value of field
-                TItem[TKey1]
-            : never
-          : never;
-      };
+  ? FilterItemByFields<TItem, TopLevelFields<TItem>>
+  : // Otherwise filter each key of fields individually
+    {
+      [TKey1 in keyof TFields]: TKey1 extends keyof TItem
+        ? // If value of field is an object, filter nested fields
+          TFields[TKey1] extends Record<string, any>
+          ? TItem[TKey1] extends Relation<Item<ItemData>>[]
+            ? FilterItemByFields<TItem[TKey1][number], TFields[TKey1]>[]
+            : TItem[TKey1] extends Relation<Item<ItemData>>
+            ? FilterItemByFields<TItem[TKey1], TFields[TKey1]>
+            : FilterItemByFields<
+                NonNullable<TItem[TKey1]>,
+                TFields[TKey1]
+              > | null
+          : // If value of field is a wildcard, filter by top level fields
+          TFields[TKey1] extends '*'
+          ? TItem[TKey1] extends Relation<Item<ItemData>>[]
+            ? FilterItemByFields<
+                TItem[TKey1][number],
+                TopLevelFields<TItem[TKey1][number]>
+              >[]
+            : TItem[TKey1] extends Relation<Item<ItemData>>
+            ? FilterItemByFields<TItem[TKey1], TopLevelFields<TItem[TKey1]>>
+            : FilterItemByFields<
+                NonNullable<TItem[TKey1]>,
+                TopLevelFields<NonNullable<TItem[TKey1]>>
+              > | null
+          : // If value of field is "true", return value of item
+          TFields[TKey1] extends true
+          ? // If value of item is an array of relation, return array of item keys
+            TItem[TKey1] extends Relation<Item<ItemData>>[]
+            ? ItemKey[]
+            : // If value of item is a relation, return item key
+            TItem[TKey1] extends Relation<Item<ItemData>>
+            ? ItemKey
+            : // If value of item is a relation, return item key
+            TItem[TKey1] extends Relation<Item<ItemData>> | null
+            ? ItemKey | null
+            : // If value of item is JSON, return it without __json__
+            TItem[TKey1] extends Json<JsonData>
+            ? Omit<TItem[TKey1], '__json__'>
+            : // Otherwise return value of field
+              TItem[TKey1]
+          : never
+        : never;
+    };
 
 /**
  * Value type of the item data response.

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -18,9 +18,13 @@ export type TopLevelFields<TItem> = {
 };
 
 /**
- * Returns the top level fields of an item.
+ * Returns the top level fields of an item recursively.
  */
-export type RecursiveTopLevelFields<TItem, Recursive extends '*' | true> = {
+export type RecursiveTopLevelFields<
+  TItem,
+  TFields,
+  Recursive extends { [TKey in keyof TFields]: any } | true
+> = {
   [TKey in keyof Omit<
     TItem,
     '__item__' | '__relation__'
@@ -35,7 +39,10 @@ export type FilterItemByFields<TItem, TFields> = '*' extends keyof TFields
       TItem,
       RecursiveTopLevelFields<
         TItem,
-        '*' extends keyof TFields['*'] ? '*' : true
+        TFields['*'],
+        '*' extends keyof TFields['*']
+          ? { [TKey in keyof TFields['*']]: TFields['*'][TKey] }
+          : true
       >
     >
   : // If fields are undefined, filter by top level fields

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -17,3 +17,15 @@ export type MaybeArray<T> = T | T[];
  * Returns an optional promise type.
  */
 export type MaybePromise<T> = T | Promise<T>;
+
+/**
+ * List of primitive types.
+ */
+export type Primitive =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | bigint
+  | symbol;

--- a/src/users/createUser.ts
+++ b/src/users/createUser.ts
@@ -26,5 +26,6 @@ export async function createUser<
   data: ItemDataRequest<TItem>,
   query?: TQuery
 ): Promise<ItemDataResponse<TItem, TQuery>> {
+  // @ts-expect-error: Excessive stack depth comparing types
   return createItem(client, 'directus_users', data, query);
 }

--- a/src/users/createUsers.ts
+++ b/src/users/createUsers.ts
@@ -26,5 +26,6 @@ export async function createUsers<
   data: ItemDataRequest<TItem>[],
   query?: TQuery
 ): Promise<ItemDataResponse<TItem, TQuery>[]> {
+  // @ts-expect-error: Excessive stack depth comparing types
   return createItems(client, 'directus_users', data, query);
 }


### PR DESCRIPTION
## Context

It is already possible to use wildcards and nested wildcards queries from a functional point of view.
However, from a type checking point of view it was only possible to do that kind of query:

### Before

```typescript
// ✅ Valid
const defaultHeader = await readItem(directus, 'header', 'default-header', {
  fields: {
    primary_action: '*'
})
```

but was not for that kind of query:
```typescript
// ❌ Invalid
const defaultHeader = await readItem(directus, 'header', 'default-header', {
  fields: {
    primary_action: {
      '*': true
    }
})

// ❌ Invalid
const defaultHeader = await readItem(directus, 'header', 'default-header', {
  fields: {
    '*': true,
})

// ❌ Invalid
const defaultHeader = await readItem(directus, 'header', 'default-header', {
  fields: {
    '*': {
      '*': true
    },
})
```

### Now

**The 3 cases described are now possible !** 

## Review Guide

Types have been added to [src/types/query.ts](src/types/query.ts) and [src/types/response.ts](src/types/response.ts).
The files have been copied/pasted from my real use-case project, and I have manually removed the modifications related to #1 and #2 inside this PR. I hope I did it right and that nothing is lacking in here.

## Tests

No tests have been added as only the types definitions have been changed.

## Checklist

- [x] I have self-reviewed my work.
- [ ] I have managed to write tests that cover my changes.

## What's next

N/A